### PR TITLE
remove blocks page top data

### DIFF
--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -15,39 +15,6 @@ export default async function page(props: IPageProps) {
         Blocks
       </h1>
 
-      <div className="mt-8 flex justify-between gap-6">
-        <div className="h-20 w-full p-4 rounded-xl bg-secondary flex justify-between items-center">
-          <div>
-            <div className="font-bold text-2xl">34%</div>
-            <div className="text-sm text-white-400">
-              Network Utilization (24h)
-            </div>
-          </div>
-          <div>
-            <TxIcon className="w-7 h-7" />
-          </div>
-        </div>
-        <div className="h-20 w-full p-4 rounded-xl bg-secondary flex justify-between items-center">
-          <div>
-            <div className="font-bold text-2xl">70,663</div>
-            <div className="text-sm text-white-400">Gas Rate</div>
-          </div>
-          <div>
-            <TxIcon className="w-7 h-7" />
-          </div>
-        </div>
-
-        <div className="h-20 w-full p-4 rounded-xl bg-secondary flex justify-between items-center">
-          <div>
-            <div className="font-bold text-2xl">5,970,172</div>
-            <div className="text-sm text-white-400">Last Safe Block</div>
-          </div>
-          <div>
-            <BlockIcon className="w-7 h-7" fill="fill-white" />
-          </div>
-        </div>
-      </div>
-
       <div className="mt-8">
         <PaginationCursor
           data={


### PR DESCRIPTION
Removing the top data on Blocks page, because this is a feature that will be handled in a future iteration.

<img width="975" alt="image" src="https://github.com/user-attachments/assets/76e8688c-dbed-475b-bea7-88c7e776f315" />
