### PR TITLE
Feat/DV-799: addresses>tokens and addresses>accounts tabs

### DIFF
--- a/src/app/addresses/[address]/page.tsx
+++ b/src/app/addresses/[address]/page.tsx
@@ -22,6 +22,7 @@ import { IEvents } from '@/common/interfaces/IEvents';
 import { fetchBalancesByAddress } from '@/services/balances';
 import { IBalances } from '@/common/interfaces/Balances';
 import { fetchTokensByAddress } from '@/services/tokens';
+import { fetchAccountsByAddress } from '@/services/accounts';
 import { ITokensByAddress } from '@/common/interfaces/Tokens';
 
 type ITabType =
@@ -30,6 +31,7 @@ type ITabType =
   | 'itxs'
   | 'tokens'
   | 'events'
+  | 'accounts'
   | 'token_transfer'
   | 'balances';
 
@@ -44,6 +46,9 @@ export default function Page() {
   >();
   const [eventsByAddress, setEventsByAddress] = useState<
     IEvents[] | undefined
+  >();
+  const [accountsByAddress, setAccountsByAddress] = useState<
+    ITokensByAddress[] | undefined
   >();
   const [transferByAddress, setTransferByAddress] = useState<
     IEvents[] | undefined
@@ -81,6 +86,9 @@ export default function Page() {
         } else if (tab === 'events') {
           data = await fetchEventsByAddress(address);
           setEventsByAddress(data?.data);
+        } else if (tab === 'accounts') {
+          data = await fetchAccountsByAddress(address);
+          setAccountsByAddress(data?.data);
         } else if (tab === 'token_transfer') {
           data = await fetchTransferEventsByAddress(address);
           setTransferByAddress(data?.data);
@@ -130,6 +138,7 @@ export default function Page() {
           txs={txsByAddress}
           tokensByAddress={tokensByAddress}
           events={eventsByAddress}
+          accountsByAddress={accountsByAddress}
           tokens={transferByAddress}
           balances={balancesByAddress}
         />

--- a/src/app/addresses/[address]/page.tsx
+++ b/src/app/addresses/[address]/page.tsx
@@ -21,11 +21,14 @@ import {
 import { IEvents } from '@/common/interfaces/IEvents';
 import { fetchBalancesByAddress } from '@/services/balances';
 import { IBalances } from '@/common/interfaces/Balances';
+import { fetchTokensByAddress } from '@/services/tokens';
+import { ITokensByAddress } from '@/common/interfaces/Tokens';
 
 type ITabType =
   | 'contract'
   | 'txs'
   | 'itxs'
+  | 'tokens'
   | 'events'
   | 'token_transfer'
   | 'balances';
@@ -35,6 +38,9 @@ export default function Page() {
   const [txsByAddress, setTxsByAddress] = useState<ITxs[] | undefined>();
   const [itxsByAddress, setITxsByAddress] = useState<
     IInternalTxs[] | undefined
+  >();
+  const [tokensByAddress, setTokensByAddress] = useState<
+    ITokensByAddress[] | undefined
   >();
   const [eventsByAddress, setEventsByAddress] = useState<
     IEvents[] | undefined
@@ -69,6 +75,9 @@ export default function Page() {
         } else if (tab === 'itxs') {
           data = await fetchInternalTxsByAddress(address);
           setITxsByAddress(data?.data);
+        } else if (tab === 'tokens') {
+          data = await fetchTokensByAddress(address);
+          setTokensByAddress(data?.data);
         } else if (tab === 'events') {
           data = await fetchEventsByAddress(address);
           setEventsByAddress(data?.data);
@@ -119,6 +128,7 @@ export default function Page() {
           currentTab={currentTab}
           itxs={itxsByAddress}
           txs={txsByAddress}
+          tokensByAddress={tokensByAddress}
           events={eventsByAddress}
           tokens={transferByAddress}
           balances={balancesByAddress}

--- a/src/app/blocks/[id]/layout.tsx
+++ b/src/app/blocks/[id]/layout.tsx
@@ -1,5 +1,5 @@
 import { ROUTER } from '@/common/constants';
-import { BlockIcon, ReturIcon } from '@/common/icons';
+import { ReturIcon } from '@/common/icons';
 import Card from '@/components/ui/Card';
 import ToolTip from '@/components/ui/ToolTip';
 import { BlocksDataProvider } from '@/context/BlocksContext';

--- a/src/app/tokens/page.tsx
+++ b/src/app/tokens/page.tsx
@@ -1,4 +1,3 @@
-import Pagination from '@/components/ui/Pagination';
 import { IPageProps } from '@/common/interfaces/RouterParams';
 import TokensTable from '@/components/tokens/TokensTable';
 import { fetchTokens } from '@/services/tokens';

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -12,6 +12,9 @@ export const ROUTER = {
     BLOCK: '/txs/block',
     ADDRESS: '/txs/address',
   },
+  ACCOUNTS: {
+    INDEX: '/accounts',
+  },
   ADDRESSES: {
     INDEX: '/addresses',
     TOKENS: '/tokens',

--- a/src/common/interfaces/Tokens.ts
+++ b/src/common/interfaces/Tokens.ts
@@ -6,3 +6,13 @@ export interface ITokens {
   name: string;
   symbol: string;
 }
+
+export interface ITokensByAddress {
+  address: string;
+  contract: string;
+  blockNumber: number;
+  blockHash: string;
+  balance: string;
+  name: string;
+  symbol: string;
+}

--- a/src/components/addresses/tabs/AccountsTable.tsx
+++ b/src/components/addresses/tabs/AccountsTable.tsx
@@ -2,7 +2,6 @@ import { ITokensByAddress } from '@/common/interfaces/Tokens';
 import ToolTip from '@/components/ui/ToolTip';
 import React from 'react';
 import { Table, TableCell, TableHeader, TableRow } from '@/components/ui/Table';
-import { parseDecimals } from '@/common/utils/ParseDecimals';
 
 type props = {
   accountsByAddress: ITokensByAddress[] | undefined;

--- a/src/components/addresses/tabs/AccountsTable.tsx
+++ b/src/components/addresses/tabs/AccountsTable.tsx
@@ -1,0 +1,32 @@
+import { ITokensByAddress } from '@/common/interfaces/Tokens';
+import ToolTip from '@/components/ui/ToolTip';
+import React from 'react';
+import { Table, TableCell, TableHeader, TableRow } from '@/components/ui/Table';
+import { parseDecimals } from '@/common/utils/ParseDecimals';
+
+type props = {
+  accountsByAddress: ITokensByAddress[] | undefined;
+};
+
+function AccountsByAddressTable({ accountsByAddress }: props) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableCell>Address</TableCell>
+        <TableCell>Balance</TableCell>
+        <TableCell>Symbol</TableCell>
+      </TableHeader>
+      {accountsByAddress?.map((tk, i) => (
+        <TableRow key={i}>
+          <TableCell>
+            <ToolTip text={tk.address} type="address" />
+          </TableCell>
+          <TableCell>{`${tk.balance}`}</TableCell>
+          <TableCell>{tk.symbol}</TableCell>
+        </TableRow>
+      ))}
+    </Table>
+  );
+}
+
+export default AccountsByAddressTable;

--- a/src/components/addresses/tabs/AddressesTabs.ts
+++ b/src/components/addresses/tabs/AddressesTabs.ts
@@ -1,7 +1,7 @@
 export const ADDRESSES_BTN_TABS = [
   { label: 'Transactions', tab: 'txs' },
   { label: 'Internal Transactions', tab: 'itxs' },
-  { label: 'Token', tab: 'token' },
+  { label: 'Tokens', tab: 'tokens' },
   { label: 'Events', tab: 'events' },
   { label: 'Token Transfer', tab: 'token_transfer' },
   { label: 'Balances', tab: 'balances' },

--- a/src/components/addresses/tabs/AddressesTxsTabsContent.tsx
+++ b/src/components/addresses/tabs/AddressesTxsTabsContent.tsx
@@ -9,7 +9,7 @@ import TxsTable from '@/components/txs/TxsTable';
 import React from 'react';
 import TokensByAddressTable from './TokensByAddressTable';
 import { ITokensByAddress } from '@/common/interfaces/Tokens';
-import { fetchTokensByAddress } from '@/services/tokens';
+import AccountsByAddressTable from './AccountsTable';
 
 type props = {
   currentTab: string;
@@ -19,6 +19,7 @@ type props = {
   tokens: IEvents[] | undefined;
   balances: IBalances[] | undefined;
   tokensByAddress: ITokensByAddress[] | undefined;
+  accountsByAddress: ITokensByAddress[] | undefined;
 };
 
 const AddressesTxsTabsContent = ({
@@ -26,6 +27,7 @@ const AddressesTxsTabsContent = ({
   txs,
   itxs,
   tokensByAddress,
+  accountsByAddress,
   events,
   tokens,
   balances,
@@ -35,6 +37,8 @@ const AddressesTxsTabsContent = ({
   if (currentTab === 'tokens')
     return <TokensByAddressTable tokensByAddress={tokensByAddress} />;
   if (currentTab === 'events') return <EventsTable events={events} />;
+  if (currentTab === 'accounts')
+    return <AccountsByAddressTable accountsByAddress={accountsByAddress} />;
   if (currentTab === 'token_transfer')
     return <TokenTransfersTable tokens={tokens} />;
   if (currentTab === 'balances') return <BalancesTable balances={balances} />;

--- a/src/components/addresses/tabs/AddressesTxsTabsContent.tsx
+++ b/src/components/addresses/tabs/AddressesTxsTabsContent.tsx
@@ -7,6 +7,9 @@ import InternalTxsTable from '@/components/itxs/InternalTxsTable';
 import TokenTransfersTable from '@/components/transfer/TokenTransfersTable';
 import TxsTable from '@/components/txs/TxsTable';
 import React from 'react';
+import TokensByAddressTable from './TokensByAddressTable';
+import { ITokensByAddress } from '@/common/interfaces/Tokens';
+import { fetchTokensByAddress } from '@/services/tokens';
 
 type props = {
   currentTab: string;
@@ -15,18 +18,22 @@ type props = {
   events: IEvents[] | undefined;
   tokens: IEvents[] | undefined;
   balances: IBalances[] | undefined;
+  tokensByAddress: ITokensByAddress[] | undefined;
 };
 
 const AddressesTxsTabsContent = ({
   currentTab,
   txs,
   itxs,
+  tokensByAddress,
   events,
   tokens,
   balances,
 }: props) => {
   if (currentTab === 'txs') return <TxsTable txs={txs} />;
   if (currentTab === 'itxs') return <InternalTxsTable itxs={itxs} />;
+  if (currentTab === 'tokens')
+    return <TokensByAddressTable tokensByAddress={tokensByAddress} />;
   if (currentTab === 'events') return <EventsTable events={events} />;
   if (currentTab === 'token_transfer')
     return <TokenTransfersTable tokens={tokens} />;

--- a/src/components/addresses/tabs/TokensByAddressTable.tsx
+++ b/src/components/addresses/tabs/TokensByAddressTable.tsx
@@ -1,0 +1,36 @@
+import { ITokensByAddress } from '@/common/interfaces/Tokens';
+import ToolTip from '@/components/ui/ToolTip';
+import React from 'react';
+import { Table, TableCell, TableHeader, TableRow } from '@/components/ui/Table';
+import { parseDecimals } from '@/common/utils/ParseDecimals';
+
+type props = {
+  tokensByAddress: ITokensByAddress[] | undefined;
+};
+
+function TokensByAddressTable({ tokensByAddress }: props) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableCell>Name</TableCell>
+        <TableCell>Address</TableCell>
+        <TableCell>Balance</TableCell>
+        <TableCell>Symbol</TableCell>
+        <TableCell>Updated at block</TableCell>
+      </TableHeader>
+      {tokensByAddress?.map((tk, i) => (
+        <TableRow key={i}>
+          <TableCell>{tk.name}</TableCell>
+          <TableCell>
+            <ToolTip text={tk.contract} type="address" />
+          </TableCell>
+          <TableCell>{`${tk.balance}`}</TableCell>
+          <TableCell>{tk.symbol}</TableCell>
+          <TableCell>{parseDecimals(tk.blockNumber)}</TableCell>
+        </TableRow>
+      ))}
+    </Table>
+  );
+}
+
+export default TokensByAddressTable;

--- a/src/components/home/txsChart/TxsChart.tsx
+++ b/src/components/home/txsChart/TxsChart.tsx
@@ -140,7 +140,7 @@ const LineChart = ({ blocks }: { blocks: IBlocks[] | undefined }) => {
               },
             },
           },
-          onClick: (e) => {
+          onClick: () => {
             if (!chartInstance.current) return;
             const tooltip = chartInstance.current.tooltip;
             if (tooltip && tooltip.dataPoints && tooltip.dataPoints.length) {

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -1,4 +1,4 @@
-import { ITokens, ITokensByAddress } from '@/common/interfaces/Tokens';
+import { ITokensByAddress } from '@/common/interfaces/Tokens';
 import { fetchData } from './api';
 import { ROUTER } from '@/common/constants';
 

--- a/src/services/accounts.ts
+++ b/src/services/accounts.ts
@@ -1,0 +1,10 @@
+import { ITokens, ITokensByAddress } from '@/common/interfaces/Tokens';
+import { fetchData } from './api';
+import { ROUTER } from '@/common/constants';
+
+export async function fetchAccountsByAddress(address: string) {
+  const response = await fetchData<ITokensByAddress[]>(
+    `${ROUTER.ACCOUNTS.INDEX}/${address}`,
+  );
+  return response;
+}

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -1,9 +1,16 @@
-import { ITokens } from '@/common/interfaces/Tokens';
+import { ITokens, ITokensByAddress } from '@/common/interfaces/Tokens';
 import { fetchData } from './api';
 import { ROUTER } from '@/common/constants';
 
 export async function fetchTokens(params: object) {
   const response = await fetchData<ITokens[]>(ROUTER.TOKENS.INDEX, params);
+  return response;
+}
+
+export async function fetchTokensByAddress(address: string) {
+  const response = await fetchData<ITokensByAddress[]>(
+    `${ROUTER.TOKENS.INDEX}/${address}`,
+  );
   return response;
 }
 


### PR DESCRIPTION
Related to PR: https://github.com/ezequiel-rodriguez/explorer-rsk-api/pull/23

This PR adds:

- addresses > tokens tab
- addresses > accounts tab

<img width="1473" alt="image" src="https://github.com/user-attachments/assets/3534b139-736b-40c5-86cc-ad9d662627b7" />


<img width="1473" alt="image" src="https://github.com/user-attachments/assets/ebfbdba1-1603-4cd1-b1d5-6a403ffc3577" />